### PR TITLE
File Read Shell Escape Issue

### DIFF
--- a/lib/fastlane/plugin/versioning_android/helper/versioning_android_helper.rb
+++ b/lib/fastlane/plugin/versioning_android/helper/versioning_android_helper.rb
@@ -13,7 +13,7 @@ module Fastlane
 
       def self.get_gradle_file_path(gradle_file)
         gradle_file = self.get_gradle_file(gradle_file)
-        return File.expand_path(gradle_file).shellescape
+        return File.expand_path(gradle_file)
       end
 
       def self.get_new_version_code(gradle_file, new_version_code)


### PR DESCRIPTION
Hey

I noticed that when trying to read in the gradle file, when I was using a regular string vs the string that was coming in from the [`get_gradle_file_path`](https://github.com/beplus/fastlane-plugin-versioning_android/blob/c8439c8f9ae2bf2938e45269c4014e4bb7f1f32f/lib/fastlane/plugin/versioning_android/helper/versioning_android_helper.rb#L14) I wasn't getting errors like `Invalid argument @ rb_sysopen` so I tried removing the `shellescape` portion and it got rid of the errors.

problem is (This might only be a windows thing) `shellescape` creates escaped double quotes:
`"\"C:/Users/Guy/Documents/Cool Project/project/android/build.gradle\""`
vs
`"C:/Users/Guy/Documents/Cool Project/project/android/build.gradle"`

and so causes issues when File.open or File.new tries to read it. Also by design the `File` class doesn't need shell escaped strings.

Made a pull request to fix it, not sure how many other people (if anyone) encountered this but it's a pretty straightforward fix