### PR TITLE
Support build.gradle.kts files

### DIFF
--- a/lib/fastlane/plugin/versioning_android/actions/android_get_version_code.rb
+++ b/lib/fastlane/plugin/versioning_android/actions/android_get_version_code.rb
@@ -31,13 +31,10 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :gradle_file,
                                   env_name: "FL_ANDROID_GET_VERSION_CODE_GRADLE_FILE",
-                               description: "(optional) Specify the path to your app build.gradle if it isn't in the default location",
+                               description: "(optional) Specify the path to your app build.gradle or build.gradle.kts if it isn't in the default location",
                                   optional: true,
                                       type: String,
-                             default_value: "app/build.gradle",
-                              verify_block: proc do |value|
-                                UI.user_error!("Could not find app build.gradle file") unless File.exist?(value) || Helper.test?
-                              end)
+                             default_value: nil)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning_android/actions/android_get_version_name.rb
+++ b/lib/fastlane/plugin/versioning_android/actions/android_get_version_name.rb
@@ -31,13 +31,10 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :gradle_file,
                                   env_name: "FL_ANDROID_GET_VERSION_NAME_GRADLE_FILE",
-                               description: "(optional) Specify the path to your app build.gradle if it isn't in the default location",
+                               description: "(optional) Specify the path to your app build.gradle or build.gradle.kts if it isn't in the default location",
                                   optional: true,
                                       type: String,
-                             default_value: "app/build.gradle",
-                              verify_block: proc do |value|
-                                UI.user_error!("Could not find app build.gradle file") unless File.exist?(value) || Helper.test?
-                              end)
+                             default_value: nil)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning_android/actions/android_set_version_code.rb
+++ b/lib/fastlane/plugin/versioning_android/actions/android_set_version_code.rb
@@ -36,13 +36,10 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :gradle_file,
                                   env_name: "FL_ANDROID_SET_VERSION_CODE_GRADLE_FILE",
-                               description: "(optional) Specify the path to your app build.gradle if it isn't in the default location",
+                               description: "(optional) Specify the path to your app build.gradle or build.gradle.kts file if it isn't in the default location",
                                   optional: true,
                                       type: String,
-                             default_value: "app/build.gradle",
-                              verify_block: proc do |value|
-                                UI.user_error!("Could not find app build.gradle file") unless File.exist?(value) || Helper.test?
-                              end),
+                             default_value: nil),
           FastlaneCore::ConfigItem.new(key: :version_code,
                                   env_name: "FL_ANDROID_SET_VERSION_CODE_VERSION_CODE",
                                description: "(optional) Set specific Version Code",

--- a/lib/fastlane/plugin/versioning_android/actions/android_set_version_name.rb
+++ b/lib/fastlane/plugin/versioning_android/actions/android_set_version_name.rb
@@ -34,13 +34,10 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :gradle_file,
                                   env_name: "FL_ANDROID_SET_VERSION_NAME_GRADLE_FILE",
-                               description: "(optional) Specify the path to your app build.gradle if it isn't in the default location",
+                               description: "(optional) Specify the path to your app build.gradle or build.gradle.kts if it isn't in the default location",
                                   optional: true,
                                       type: String,
-                             default_value: "app/build.gradle",
-                              verify_block: proc do |value|
-                                UI.user_error!("Could not find app build.gradle file") unless File.exist?(value) || Helper.test?
-                              end),
+                             default_value: nil),
           FastlaneCore::ConfigItem.new(key: :version_name,
                                   env_name: "FL_ANDROID_SET_VERSION_NAME_VERSION_NAME",
                                description: "(optional) Set specific Version Name",

--- a/lib/fastlane/plugin/versioning_android/helper/versioning_android_helper.rb
+++ b/lib/fastlane/plugin/versioning_android/helper/versioning_android_helper.rb
@@ -5,10 +5,21 @@ module Fastlane
       require "tempfile"
       require "fileutils"
 
-      GRADLE_FILE_TEST = "/tmp/fastlane/tests/versioning/app/build.gradle"
+      DEFAULT_GROOVY_GRADLE_FILE = "./app/build.gradle"
+      DEFAULT_KOTLIN_GRADLE_FILE = "./app/build.gradle.kts"
 
       def self.get_gradle_file(gradle_file)
-        return Helper.test? ? GRADLE_FILE_TEST : gradle_file
+        if gradle_file.nil?
+          if File.exist?(DEFAULT_GROOVY_GRADLE_FILE)
+            return DEFAULT_GROOVY_GRADLE_FILE
+          elsif File.exist?(DEFAULT_KOTLIN_GRADLE_FILE)
+            return DEFAULT_KOTLIN_GRADLE_FILE
+          else
+            return DEFAULT_GROOVY_GRADLE_FILE
+          end
+        else
+          return gradle_file
+        end
       end
 
       def self.get_gradle_file_path(gradle_file)
@@ -58,7 +69,7 @@ module Fastlane
           end
           file.close
         rescue => err
-          UI.error("An exception occured while reading gradle file: #{err}")
+          UI.error("An exception occurred while reading gradle file: #{err}")
           err
         end
         return value
@@ -72,7 +83,7 @@ module Fastlane
           temp_file = Tempfile.new("flSave_#{key}_ToGradleFile")
           File.open(gradle_file, "r") do |file|
             file.each_line do |line|
-              if line.include? key and found == false
+              if line.include? key and !found
                 found = true
                 line.replace line.sub(current_value.to_s, value.to_s)
               end
@@ -86,7 +97,7 @@ module Fastlane
           temp_file.unlink
         end
 
-        return found == true ? value : -1
+        return found ? value : -1
       end
     end
   end

--- a/spec/android_get_version_code_action_spec.rb
+++ b/spec/android_get_version_code_action_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::AndroidGetVersionCodeAction do
-  describe "Get Version Code" do
+  describe "Get Version Code (Groovy)" do
     before do
-      copy_project_files_fixture
+      copy_groovy_project_files_fixture
     end
 
     it "should return Version Code from app build.gradle file" do
@@ -18,6 +18,30 @@ describe Fastlane::Actions::AndroidGetVersionCodeAction do
         android_get_version_code
       end').runner.execute(:test)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_CODE]).to eq("17")
+    end
+
+    after do
+      remove_project_files_fixture
+    end
+  end
+
+  describe "Get Version Code (Kotlin)" do
+    before do
+      copy_kotlin_project_files_fixture
+    end
+
+    it "should return Version Code from app build.gradle.kts file" do
+      result = Fastlane::FastFile.new.parse('lane :test do
+        android_get_version_code
+      end').runner.execute(:test)
+      expect(result).to eq("123")
+    end
+
+    it "should set Version Code to ANDROID_VERSION_CODE shared value" do
+      Fastlane::FastFile.new.parse('lane :test do
+        android_get_version_code
+      end').runner.execute(:test)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_CODE]).to eq("123")
     end
 
     after do

--- a/spec/android_get_version_name_action_spec.rb
+++ b/spec/android_get_version_name_action_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::AndroidGetVersionNameAction do
-  describe "Get Version Name" do
+  describe "Get Version Name (Groovy)" do
     before do
-      copy_project_files_fixture
+      copy_groovy_project_files_fixture
     end
 
     it "should return Version Name from app build.gradle file" do
@@ -18,6 +18,30 @@ describe Fastlane::Actions::AndroidGetVersionNameAction do
         android_get_version_name
       end').runner.execute(:test)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq("1.23.4")
+    end
+
+    after do
+      remove_project_files_fixture
+    end
+  end
+
+  describe "Get Version Name (Kotlin)" do
+    before do
+      copy_kotlin_project_files_fixture
+    end
+
+    it "should return Version Name from app build.gradle.kts file" do
+      result = Fastlane::FastFile.new.parse('lane :test do
+        android_get_version_name
+      end').runner.execute(:test)
+      expect(result).to eq("3.45.6")
+    end
+
+    it "should set Version Name to ANDROID_VERSION_NAME shared value" do
+      Fastlane::FastFile.new.parse('lane :test do
+        android_get_version_name
+      end').runner.execute(:test)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq("3.45.6")
     end
 
     after do

--- a/spec/android_set_version_code_action_spec.rb
+++ b/spec/android_set_version_code_action_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::AndroidSetVersionCodeAction do
-  describe "Set Version Code" do
+  describe "Set Version Code (Groovy)" do
     before do
-      copy_project_files_fixture
+      copy_groovy_project_files_fixture
     end
 
     it "should increment Version Code and return its new value" do
@@ -18,6 +18,44 @@ describe Fastlane::Actions::AndroidSetVersionCodeAction do
         android_set_version_code
       end').runner.execute(:test)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_NEW_VERSION_CODE]).to eq(18)
+    end
+
+    it "should set specific Version Code and return its new value" do
+      result = Fastlane::FastFile.new.parse('lane :test do
+        android_set_version_code(version_code: 17)
+      end').runner.execute(:test)
+      expect(result).to eq(17)
+    end
+
+    it "should set specific Version Code to ANDROID_NEW_VERSION_CODE shared value" do
+      Fastlane::FastFile.new.parse('lane :test do
+        android_set_version_code(version_code: 17)
+      end').runner.execute(:test)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_NEW_VERSION_CODE]).to eq(17)
+    end
+
+    after do
+      remove_project_files_fixture
+    end
+  end
+
+  describe "Set Version Code (Kotlin)" do
+    before do
+      copy_kotlin_project_files_fixture
+    end
+
+    it "should increment Version Code and return its new value" do
+      result = Fastlane::FastFile.new.parse('lane :test do
+        android_set_version_code
+      end').runner.execute(:test)
+      expect(result).to eq(124)
+    end
+
+    it "should set incremented Version Code to ANDROID_NEW_VERSION_CODE shared value" do
+      Fastlane::FastFile.new.parse('lane :test do
+        android_set_version_code
+      end').runner.execute(:test)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_NEW_VERSION_CODE]).to eq(124)
     end
 
     it "should set specific Version Code and return its new value" do

--- a/spec/android_set_version_name_action_spec.rb
+++ b/spec/android_set_version_name_action_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::AndroidSetVersionNameAction do
-  describe "Set Version Name" do
+  describe "Set Version Name (Groovy)" do
     before do
-      copy_project_files_fixture
+      copy_groovy_project_files_fixture
     end
 
     it "should set Version Name to specific value" do
@@ -18,6 +18,30 @@ describe Fastlane::Actions::AndroidSetVersionNameAction do
         android_set_version_name(version_name: "2.34.5")
       end').runner.execute(:test)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_NEW_VERSION_NAME]).to eq("2.34.5")
+    end
+
+    after do
+      remove_project_files_fixture
+    end
+  end
+
+  describe "Set Version Name (Kotlin)" do
+    before do
+      copy_kotlin_project_files_fixture
+    end
+
+    it "should set Version Name to specific value" do
+      result = Fastlane::FastFile.new.parse('lane :test do
+        android_set_version_name(version_name: "5.67.8")
+      end').runner.execute(:test)
+      expect(result).to eq("5.67.8")
+    end
+
+    it "should set Version Name to ANDROID_NEW_VERSION_NAME shared value" do
+      Fastlane::FastFile.new.parse('lane :test do
+        android_set_version_name(version_name: "5.67.8")
+      end').runner.execute(:test)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_NEW_VERSION_NAME]).to eq("5.67.8")
     end
 
     after do

--- a/spec/fixtures/app/build.gradle.kts
+++ b/spec/fixtures/app/build.gradle.kts
@@ -1,0 +1,36 @@
+// From https://github.com/gradle/kotlin-dsl-samples/blob/master/samples/hello-android/app/build.gradle.kts
+import org.jetbrains.kotlin.config.KotlinCompilerVersion
+
+plugins {
+    id("com.android.application")
+    kotlin("android")
+    kotlin("android.extensions")
+}
+
+android {
+    compileSdkVersion(27)
+    defaultConfig {
+        applicationId = "org.gradle.kotlin.dsl.samples.androidstudio"
+        minSdkVersion(15)
+        targetSdkVersion(27)
+        versionCode = 123
+        versionName = "3.45.6"
+        testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
+    }
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+        }
+    }
+}
+
+dependencies {
+    implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
+    implementation(kotlin("stdlib-jdk7", KotlinCompilerVersion.VERSION))
+    implementation("com.android.support:appcompat-v7:27.1.1")
+    implementation("com.android.support.constraint:constraint-layout:1.1.0")
+    testImplementation("junit:junit:4.12")
+    androidTestImplementation("com.android.support.test:runner:1.0.2")
+    androidTestImplementation("com.android.support.test.espresso:espresso-core:3.0.2")
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,13 +14,20 @@ require 'fastlane/plugin/versioning_android' # import the actual plugin
 
 Fastlane.load_actions # load other actions (in case your plugin calls other actions or shared values)
 
-def copy_project_files_fixture
-  FileUtils.mkdir_p("/tmp/fastlane/tests/versioning")
-  source = "./spec/fixtures"
-  destination = "/tmp/fastlane/tests/versioning"
-  FileUtils.copy_entry(source, destination)
+def copy_groovy_project_files_fixture
+  FileUtils.mkdir_p("./fastlane/app")
+  source = "./spec/fixtures/app/build.gradle"
+  destination = "./fastlane/app/build.gradle"
+  FileUtils.copy_file(source, destination)
+end
+
+def copy_kotlin_project_files_fixture
+  FileUtils.mkdir_p("./fastlane/app")
+  source = "./spec/fixtures/app/build.gradle.kts"
+  destination = "./fastlane/app/build.gradle.kts"
+  FileUtils.copy_file(source, destination)
 end
 
 def remove_project_files_fixture
-  FileUtils.rm_rf("/tmp/fastlane/tests/versioning")
+  FileUtils.rm_rf("./fastlane/app")
 end

--- a/spec/versioning_android_helper_spec.rb
+++ b/spec/versioning_android_helper_spec.rb
@@ -1,16 +1,40 @@
 require 'spec_helper'
 
 describe Fastlane::Helper::VersioningAndroidHelper do
-  describe "Versioning Android Helper" do
+  describe "Versioning Android Helper (Groovy)" do
     it "should return path to build.gradle" do
       result = Fastlane::Helper::VersioningAndroidHelper.get_gradle_file(nil)
-      expect(result).to eq(Fastlane::Helper::VersioningAndroidHelper::GRADLE_FILE_TEST)
+      expect(result).to eq(Fastlane::Helper::VersioningAndroidHelper::DEFAULT_GROOVY_GRADLE_FILE)
     end
 
     it "should return absolute path to build.gradle" do
-      xcodeproj = Fastlane::Helper::VersioningAndroidHelper::GRADLE_FILE_TEST
-      result = Fastlane::Helper::VersioningAndroidHelper.get_gradle_file_path(xcodeproj)
-      expect(result).to eq("/tmp/fastlane/tests/versioning/app/build.gradle")
+      gradle_file = Fastlane::Helper::VersioningAndroidHelper::DEFAULT_GROOVY_GRADLE_FILE
+      result = Fastlane::Helper::VersioningAndroidHelper.get_gradle_file_path(gradle_file)
+      expect(result).to eq File.expand_path("./app/build.gradle")
+    end
+  end
+
+  describe "Versioning Android Helper (Kotlin)" do
+    before do
+      FileUtils.mkdir_p("./app")
+      source = "./spec/fixtures/app/build.gradle.kts"
+      destination = "./app/build.gradle.kts"
+      FileUtils.copy_file(source, destination)
+    end
+
+    it "should return path to build.gradle.kts" do
+      result = Fastlane::Helper::VersioningAndroidHelper.get_gradle_file(nil)
+      expect(result).to eq(Fastlane::Helper::VersioningAndroidHelper::DEFAULT_KOTLIN_GRADLE_FILE)
+    end
+
+    it "should return absolute path to build.gradle.kts" do
+      gradle_file = Fastlane::Helper::VersioningAndroidHelper::DEFAULT_KOTLIN_GRADLE_FILE
+      result = Fastlane::Helper::VersioningAndroidHelper.get_gradle_file_path(gradle_file)
+      expect(result).to eq File.expand_path("./app/build.gradle.kts")
+    end
+
+    after do
+      FileUtils.rm_rf("./app")
     end
   end
 end


### PR DESCRIPTION
- remove dependency of `Helper.test?`
- test in a `./app/` folder instead of `./tmp/`
- dynamically check for presence of Groovy, than Kotlin build  file